### PR TITLE
Remove gcloud, bump to 1.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM baiduxlab/sgx-rust:1.0.1
 
 # Add all the things we need to build chainlink
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y curl git gcc libssl1.0.0 build-essential jq lsb-release
+RUN apt-get update && apt-get install -y curl git gcc libssl1.0.0 build-essential jq
 
 # Install go 1.10.3
 RUN cd /usr/local && \
@@ -79,9 +79,3 @@ RUN git clone https://github.com/baidu/rust-sgx-sdk/ /opt/rust-sgx-sdk
 # Install tarpaulin for rust code coverage
 ENV PATH /root/.cargo/bin:$PATH
 RUN RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
-
-# Google Cloud SDK
-RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-    echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update -y && apt-get install google-cloud-sdk kubectl -y

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,3 @@
 .PHONY: all
 all:
-	docker build -t smartcontract/builder:1.0.7 .
+	docker build -t smartcontract/builder:1.0.8 .

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -2,7 +2,7 @@
   type: push
   service: builder
   image_name: smartcontract/builder
-  image_tag: "1.0.7"
+  image_tag: "1.0.8"
   registry: https://index.docker.io/v1/
   encrypted_dockercfg_path: dockercfg.encrypted
 


### PR DESCRIPTION
We now have a separate image https://github.com/smartcontractkit/deployer for this.