### PR TITLE
Add Chromium dependencies and bump to 1.0.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,3 +87,20 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update -y && apt-get install google-cloud-sdk kubectl -y
+
+# Puppeteer Chromium dependences: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+# installs, work.
+RUN apt-get install -y wget libgconf-2-4 --no-install-recommends \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /src/*.deb
+
+# It's a good idea to use dumb-init to help prevent zombie chrome processes.
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,3 @@
 .PHONY: all
 all:
-	docker build -t smartcontract/builder:1.0.13 .
+	docker build -t smartcontract/builder:1.0.14 .

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -2,7 +2,7 @@
   type: push
   service: builder
   image_name: smartcontract/builder
-  image_tag: "1.0.13"
+  image_tag: "1.0.14"
   registry: https://index.docker.io/v1/
   encrypted_dockercfg_path: dockercfg.encrypted
 


### PR DESCRIPTION
Not Chromium itself. That is installed via

```
yarn add puppeteer
```

Later on in the CI cycle in accordance with Chainlink's package.json