### PR TITLE
Remove slither from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,9 +111,8 @@ RUN apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:ethereum/ethereum \
     && apt-get -y update && apt-get install -y solc ethereum
 
-# Install python & slither
+# Install python
 RUN apt-get install -y python3.7 python3-pip
-RUN pip3 install slither-analyzer
 
 # Clean up apt's intermediate files
 RUN rm -rf /var/lib/apt/lists/* \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,3 @@
 .PHONY: all
 all:
-	docker build -t smartcontract/builder:1.0.22 .
+	docker build -t smartcontract/builder:1.0.23 .

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -2,7 +2,7 @@
   type: push
   service: builder
   image_name: smartcontract/builder
-  image_tag: "1.0.22"
+  image_tag: "1.0.23"
   registry: https://index.docker.io/v1/
   encrypted_dockercfg_path: dockercfg.encrypted
 


### PR DESCRIPTION
Better to install slither during CI so that it's version can be easily managed from one repository