### PR TITLE
Downgrade node to v10.x. SHA3 fails to compile with node-gyp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN set -ex \
 done
 
 # Node
-ENV NODE_VERSION 12.10.0
+ENV NODE_VERSION 10.16.3
 
 RUN curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,3 @@
 .PHONY: all
 all:
-	docker build -t smartcontract/builder:1.0.23 .
+	docker build -t smartcontract/builder:1.0.24 .

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -2,7 +2,7 @@
   type: push
   service: builder
   image_name: smartcontract/builder
-  image_tag: "1.0.23"
+  image_tag: "1.0.24"
   registry: https://index.docker.io/v1/
   encrypted_dockercfg_path: dockercfg.encrypted
 


### PR DESCRIPTION
- https://github.com/phusion/node-sha3/issues/60