### PR TITLE
Add Cypress dependencies, remove slither

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,9 @@ RUN apt-get install -y wget libgconf-2-4 --no-install-recommends \
     && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst \
       --no-install-recommends
 
+# Install dependencies needed to run cypress
+RUN apt-get update && apt-get install -y xvfb libgtk-3-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
+
 # Install the C++ solidity compiler.
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:ethereum/ethereum \
@@ -111,7 +114,6 @@ RUN add-apt-repository -y ppa:ethereum/ethereum \
 
 # Install python & slither
 RUN apt-get install -y python3.7 python3-pip
-RUN pip3 install slither-analyzer
 
 # Clean up apt's intermediate files
 RUN rm -rf /var/lib/apt/lists/* \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,3 @@
 .PHONY: all
 all:
-	docker build -t smartcontract/builder:1.0.24 .
+	docker build -t smartcontract/builder:1.0.25 .

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -2,7 +2,7 @@
   type: push
   service: builder
   image_name: smartcontract/builder
-  image_tag: "1.0.24"
+  image_tag: "1.0.25"
   registry: https://index.docker.io/v1/
   encrypted_dockercfg_path: dockercfg.encrypted
 


### PR DESCRIPTION
Adds Cypress dependencies, also removes direct slither installation as requested [here](https://github.com/smartcontractkit/builder/pull/31).