### PR TITLE
Add deprecated message back in

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED
+
+Chainlink no longer uses this image for any builds.
+
 # Builder Docker Image
 
 This project contains the docker image used as part of [Chainlink](https://github.com/smartcontractkit/chainlink)'s Continuous Integration (CI).


### PR DESCRIPTION
Builder is now fully removed (boy we move fast):

https://github.com/smartcontractkit/chainlink/pull/5389/files